### PR TITLE
add CPSID/CPSIE for RV32

### DIFF
--- a/asm15.js
+++ b/asm15.js
@@ -533,6 +533,8 @@ var cmdlist_rv32c = [
 ["ecall",[0x00000073]],
 ["ebreak",[0x00100073]],
 
+["cpsid",[0x300477f3]],
+["cpsie",[0x300467f3]],
 ];
 
 var patlist_m0 = [];

--- a/index.html
+++ b/index.html
@@ -103,6 +103,7 @@ DATA/DATABは1バイトずつ、DATAWは2バイトずつ、DATALは4バイトず
 <ul>
 <li>参考<br>
 <a href="armasm.html">Cortex-M0 ARMマシン語表（抜粋）</a><br>
+<a href="rvasm.html">RV32C RISC-Vマシン語表 （asm15r、抜粋）</a><br>
 <a href="cpuemu.html">IchigoJam マシン語エミュレーター on web</a>（2進数表記をコピペで一部対応、<a href="https://fukuno.jig.jp/1328">説明</a>）<br>
 <a href="disasm15.html">asm15対応逆アセンブラ</a>
 </li>


### PR DESCRIPTION
RISC-Vでの表記方法とは違うので要検討
割り込み許可禁止のasm15専用の何かを定めてもいいかも